### PR TITLE
 docker-compose version to 2.3 and added resource contraints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.3'
 
 services:
   go-server:
@@ -7,6 +7,9 @@ services:
     command: go run index.go
     networks: [net]
     volumes: ['.:/root']
+    mem_limit: 512m
+    cpu_count: 1
+    cpu_percent: 10
 
   php-server:
     image: koolob/swoole-docker       # swoole php Repository
@@ -14,6 +17,9 @@ services:
     command: php index.php
     networks: [net]
     volumes: ['.:/root']
+    mem_limit: 512m
+    cpu_count: 1
+    cpu_percent: 10
 
   node-server:
     image: node                       # node js Official Repository
@@ -21,6 +27,9 @@ services:
     command: node index.js
     networks: [net]
     volumes: ['.:/root']
+    mem_limit: 512m
+    cpu_count: 1
+    cpu_percent: 10
 
   benchmark-client:
     image: williamyeh/wrk           # A minimal wrk image: Modern HTTP benchmarking tool


### PR DESCRIPTION
+ docker-compose version 3 is not really necessary unless using docker in swarm mode
       + docker swarm mode requires docker stack deploy and stack settings for resource constraints and it gets messy.
+ memory and CPU constraints were added for a more fair playground