### PR TITLE
Added japronto server to Python implementation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,9 @@ services:
     volumes: ['.:/root']
 
   python-server:
-    image: python:3         
+    image: japronto/japronto       
     working_dir: /root
-    command: >
-      sh -c "bash -c "pip3 install git+https://github.com/squeaky-pl/japronto && 
-             python3 index.py"
+    command: --port 8084 --script index.py
     networks: [net]
     volumes: ['.:/root']
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,11 @@ services:
     volumes: ['.:/root']
 
   python-server:
-    image: python:3                   # python 3 Official Repository
+    image: python:3         
     working_dir: /root
-    command: python3 index.py
+    command: >
+      sh -c "bash -c "pip3 install git+https://github.com/squeaky-pl/japronto && 
+             python3 index.py"
     networks: [net]
     volumes: ['.:/root']
 

--- a/index.py
+++ b/index.py
@@ -1,4 +1,4 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 
 class MyServer(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -11,5 +11,9 @@ class MyServer(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         return
 
-httpd = HTTPServer(("python-server", 8084), MyServer)
-httpd.serve_forever()
+# httpd = HTTPServer(("python-server", 8084), MyServer)
+# httpd.serve_forever()
+
+
+with ThreadingHTTPServer(("python-server", 8084), MyServer) as httpd:
+    httpd.serve_forever()

--- a/index.py
+++ b/index.py
@@ -1,19 +1,8 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from japronto import Application
 
-class MyServer(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-type", "text/plain")
-        self.end_headers()
-        self.wfile.write(bytes("Hello World Python\n", "utf-8"))
+def hello(request):
+    return request.Response(text='Hello world!')
 
-    # To silence the log message
-    def log_message(self, format, *args):
-        return
-
-# httpd = HTTPServer(("python-server", 8084), MyServer)
-# httpd.serve_forever()
-
-
-with ThreadingHTTPServer(("python-server", 8084), MyServer) as httpd:
-    httpd.serve_forever()
+app = Application()
+app.router.add_route('/', hello)
+app.run(port=8084)


### PR DESCRIPTION
I have added Japronto server because Python official documentation doesn't recommend the HTTP server and socket implementation usage for this kind of test. So we have to use another solution. Am sure the python server is having some socket issue right?

So the implementation is actually pretty forward 
```python
from japronto import Application

def hello(request):
    return request.Response(text='Hello world!')

app = Application()
app.router.add_route('/', hello)
app.run(port=8084)

```